### PR TITLE
マイページのViwe（仮）作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,11 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
+    #新規登録時許可
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    #情報更新時許可
+    devise_parameter_sanitizer.permit(:account_update,keys:[:nickname])
   end
+  
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
+    
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,43 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
+<h2>編集ページ <%= resource_name.to_s.humanize %></h2>
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+  <div class= 'user-field'>
+    <div class="field">
+      <%= f.label :ユーザー名 %><br />
+      <%= f.text_field :nickname, autofocus: true %>
+    </div>
+    <div class="field">
+      <%= f.label :メールアドレス %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
     <% end %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="field">
+      <%= f.label :パスワード変更 %> <i>（変更したい場合）</i><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+     <% if @minimum_password_length %>
+       <br />
+       <em><%= @minimum_password_length %> characters minimum</em>
+     <% end %>
+    </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
+    <div class="field">
+     <%= f.label :パスワード変更（確認） %><br />
+     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
+    <div class="field">
+     <%= f.label :現在のパスワード %>
+     <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Update" %>
+    </div>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<%= link_to "MYページに戻る", :back %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,30 @@
-<h1>Users#show</h1>
-<p>Find me in app/views/users/show.html.erb</p>
-<p>MyPage <%= @user.id %></p>
+<h1>MyPage</h1>
+
+<p>ニックネーム名：<%= @user.nickname %></p>
+<%#プロフィールの内容を表示%>
+<%= @user.email%>
+<%#プロフィールの内容編集ボタン%>
+<li><%=link_to "プロフィールを編集する",edit_user_registration_path(current_user.id)%></li>
+<%#投稿内容一覧%>
+  <% @user.tweets.each do |tweet|%>
+    <div class="user_post">
+      <section class="card">
+          <div>
+           <%= image_tag tweet.image.variant(resize: '350x300'), class: 'message-image' if tweet.image.attached? %>
+          <div>
+          <div class="card-content">
+            <h4 class="card-title">
+            <li><%= link_to tweet.title, tweet_path(tweet.id), method: :get %></li>
+            </h4>
+          </div>
+          <div class="card-link">
+            <%= tweet.user.nickname %>
+          </div>
+      </section>
+    </div>
+  <% end %>
+<%#フォローメンバーの投稿表示%>
+
+
+
+


### PR DESCRIPTION
＃What
マイページの仮のviwe作成
#Why
userの投稿内容・userのプロフィール変更画面へのルーティングを実施。
他に、マイページにはフォロー機能実施後にフォローした人の新規投稿記事がされる様にするため、仮で作成。


